### PR TITLE
Fix namespace and refactor arithmetic operations

### DIFF
--- a/ArthamitcOpertions/Arthmatic.cs
+++ b/ArthamitcOpertions/Arthmatic.cs
@@ -2,7 +2,7 @@
 
 namespace ArithmeticOperations
 {
-    public class Arithmetic
+    public static class Arithmetic
     {
         public static int Sum(int x, int y)
         {

--- a/ArthamitcOpertions/Arthmatic.cs
+++ b/ArthamitcOpertions/Arthmatic.cs
@@ -1,27 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace ArthamitcOpertions
+namespace ArithmeticOperations
 {
-   public class Arthmatic
+    public class Arithmetic
     {
-        public int Sum(int x ,int y)
+        public static int Sum(int x, int y)
         {
             return x + y;
         }
 
-        public int Div(int x, int y)
+        public static int Div(int x, int y)
         {
             return x / y;
         }
-        public int Sub(int x, int y)
+
+        public static int Sub(int x, int y)
         {
             return x - y;
         }
-        public int mul(int x, int y)
+
+        public static int Mul(int x, int y)
         {
             return x * y;
         }

--- a/TestProject1/TestProject1.csproj
+++ b/TestProject1/TestProject1.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/UnitTestProject1/M_UNIT_UnitTest1.cs
+++ b/UnitTestProject1/M_UNIT_UnitTest1.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-
-using ArthamitcOpertions;
-using System.Runtime.CompilerServices;
+using ArithmeticOperations;
 
 namespace UnitTestProject1
 {
@@ -11,41 +8,32 @@ namespace UnitTestProject1
     public class M_UNIT_UnitTest1
     {
         public int i = 10, j = 20;
-        Arthmatic ar = new Arthmatic();
 
         [TestMethod]
         public void TestSum()
         {
-           
-            Assert.AreEqual(30, ar.Sum(i, j));
+            Assert.AreEqual(30, Arithmetic.Sum(i, j));
         }
 
         [TestMethod]
         public void TestSub()
         {
-            Assert.AreEqual(-10 ,ar.Sub(i, j));
+            Assert.AreEqual(-10, Arithmetic.Sub(i, j));
         }
 
         [TestMethod]
-
         public void TestMul()
         {
-            Assert.AreEqual(200 ,ar.mul(i, j));
+            Assert.AreEqual(200, Arithmetic.Mul(i, j));
         }
 
-        /* this is Mtest tesing theree are inuld method that we useed 
-         * N-unit for .Net Fremwork 
-         * X-Unit For .Net core
-         */
-        
-
         [TestMethod]
-        public  void TestDiv()
+        public void TestDiv()
         {
-            Assert.AreEqual(2, ar.Div(20, 10));
+            Assert.AreEqual(2, Arithmetic.Div(20, 10));
             Assert.IsTrue(true);
-            Assert.AreNotEqual(11 ,ar.Div(20, 10));
-            Assert.AreNotSame(ar, ar.Div(20, 10));
+            Assert.AreNotEqual(11, Arithmetic.Div(20, 10));
+            Assert.AreNotSame(12, Arithmetic.Div(20, 10));
         }
     }
 }


### PR DESCRIPTION
Corrected the namespace from `ArhamiticOpertions` to `ArithmeticOperations` and renamed the class from `Arthmatic` to `Arithmetic`. Changed instance methods to static methods and standardized method names to PascalCase. Updated test files to reflect these changes, ensuring all tests validate the expected outcomes. Removed unused and commented-out code for clarity.